### PR TITLE
Import stuff from base instead of mtl

### DIFF
--- a/pkg/hs/avers/benchmark/Benchmark.hs
+++ b/pkg/hs/avers/benchmark/Benchmark.hs
@@ -7,6 +7,7 @@ module Main where
 
 import           Control.Applicative
 import           Control.Monad
+import           Control.Monad.IO.Class
 import           Control.Monad.State
 
 import           Data.Monoid

--- a/pkg/hs/avers/src/Avers/Handle.hs
+++ b/pkg/hs/avers/src/Avers/Handle.hs
@@ -6,6 +6,7 @@ module Avers.Handle (newHandle, newState) where
 
 import           Safe
 
+import           Control.Monad
 import           Control.Monad.Except
 
 import           Control.Concurrent

--- a/pkg/hs/avers/src/Avers/Metrics.hs
+++ b/pkg/hs/avers/src/Avers/Metrics.hs
@@ -1,6 +1,7 @@
 module Avers.Metrics where
 
 
+import           Control.Monad.IO.Class
 import           Control.Monad.State
 import           Control.Exception.Base
 

--- a/pkg/hs/avers/src/Avers/Storage.hs
+++ b/pkg/hs/avers/src/Avers/Storage.hs
@@ -18,6 +18,8 @@ import           Control.Applicative
 import           Control.Concurrent
 import           Control.Concurrent.STM
 
+import           Control.Monad
+import           Control.Monad.IO.Class
 import           Control.Monad.Random (getRandomR, evalRandIO)
 import           Control.Monad.State
 import           Control.Monad.Except

--- a/pkg/hs/avers/src/Avers/Storage/Backend.hs
+++ b/pkg/hs/avers/src/Avers/Storage/Backend.hs
@@ -31,6 +31,7 @@ module Avers.Storage.Backend
 import           Prelude hiding (lookup)
 
 import           Control.Monad.Except
+import           Control.Monad.IO.Class
 import           Control.Monad.State
 
 import           Data.Aeson (Value, Result(..))

--- a/pkg/hs/avers/src/Avers/Types.hs
+++ b/pkg/hs/avers/src/Avers/Types.hs
@@ -14,6 +14,7 @@ import           GHC.Generics
 import           Control.Applicative
 
 import           Control.Monad.Except
+import           Control.Monad.IO.Class
 import           Control.Monad.State
 
 import           Control.Concurrent.STM


### PR DESCRIPTION
There is an intention to stop re-exporting functions from `base` in future versions of `mtl`: https://github.com/haskell/mtl/pull/74
This PR brings `avers` in line with the proposed change.